### PR TITLE
Update Bookview image links with absolute URLs

### DIFF
--- a/application/controllers/Bookview.php
+++ b/application/controllers/Bookview.php
@@ -223,7 +223,7 @@ class Bookview extends CI_Controller {
 			if($type=='subject'){
 				$subjDict=$this->newbooksconfig->getSubjectDict();
 			}
-			echo "<a href='".$baseURL."/index.php/Bookview/repeat/".$age."/".$fundPad.urlencode($facet)."/".$size."'><div id='newBooksBack' role='button' tabindex='0'><img src='/newBooks/images/ic_arrow_back_black_24dp_2x.png' alt='New books search: Go back'></img></div></a>";		//Make this link read from newbooksconfig
+			echo "<a href='".$baseURL."/index.php/Bookview/repeat/".$age."/".$fundPad.urlencode($facet)."/".$size."'><div id='newBooksBack' role='button' tabindex='0'><img src='" . $baseURL ."/images/ic_arrow_back_black_24dp_2x.png' alt='New books search: Go back'></img></div></a>";		//Make this link read from newbooksconfig
 			
 			echo "<br /><div class='resultsHead'><strong>";
 			if($dateCutoff=='none'){

--- a/application/controllers/Bookview.php
+++ b/application/controllers/Bookview.php
@@ -202,7 +202,7 @@ class Bookview extends CI_Controller {
 		else{
 			$this->load->view('templates/headerM',$data);
 		}
-		echo "<div id='loadingCover' style='width:100%;height:100%;background-color:rgba(255,255,255,.8);position:fixed;z-index:4;'><img class='centerSpin' style='position:relative;width:24px;left:50%;top:50px;' src='/newBooks/images/spinning-wheel.gif'></img></div>";		//Using inline style to ensure it's applied early in the load process
+		echo "<div id='loadingCover' style='width:100%;height:100%;background-color:rgba(255,255,255,.8);position:fixed;z-index:4;'><img class='centerSpin' style='position:relative;width:24px;left:50%;top:50px;' src='" . $baseURL ."/images/spinning-wheel.gif'></img></div>";		//Using inline style to ensure it's applied early in the load process
 		if($type=='format'){
 			$fundPad='SFORMAT_';
 		}


### PR DESCRIPTION
I found a couple of spots in Bookview where `<img>` tags were hardcoded to use the 'newBooks' subdirectory rather than the one I'd created for my project. I've updated to insert the $baseurl variable instead.